### PR TITLE
Run catkin_lint on packages

### DIFF
--- a/easy_handeye/CMakeLists.txt
+++ b/easy_handeye/CMakeLists.txt
@@ -2,11 +2,11 @@ cmake_minimum_required(VERSION 2.8.3)
 project(easy_handeye)
 
 find_package(catkin REQUIRED COMPONENTS
-    visp_hand2eye_calibration
-    std_msgs
     geometry_msgs
-    std_srvs
     message_generation
+    std_msgs
+    std_srvs
+    visp_hand2eye_calibration
 )
 
 catkin_python_setup()
@@ -19,33 +19,37 @@ add_message_files(
 
 add_service_files(
     FILES
-    TakeSample.srv
     ComputeCalibration.srv
     RemoveSample.srv
+    TakeSample.srv
 )
 
 generate_messages(
     DEPENDENCIES
-    std_msgs
     geometry_msgs
+    std_msgs
     visp_hand2eye_calibration
 )
 
 catkin_package(
-    CATKIN_DEPENDS message_runtime geometry_msgs visp_hand2eye_calibration std_msgs geometry_msgs
+    CATKIN_DEPENDS geometry_msgs message_runtime std_msgs visp_hand2eye_calibration
 )
 
 install(PROGRAMS
     scripts/calibrate.py
     scripts/handeye_calibration_commander.py
     scripts/publish.py
+    src/${PROJECT_NAME}/handeye_calibration.py
+    src/${PROJECT_NAME}/handeye_calibrator.py
+    src/${PROJECT_NAME}/handeye_client.py
+    src/${PROJECT_NAME}/handeye_server.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
 install(FILES
     launch/calibrate.launch
     launch/publish.launch
-    launch/rqt_easy_handeye.perspective
-    launch/rviz_easy_handeye.config
+    launch/rqt_${PROJECT_NAME}.perspective
+    launch/rviz_${PROJECT_NAME}.config
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch
 )

--- a/easy_handeye/package.xml
+++ b/easy_handeye/package.xml
@@ -3,8 +3,8 @@
     <name>easy_handeye</name>
     <version>0.2.0</version>
     <description>
-        This package uses visp_hand2eye_calibration to determine the
-        extrinsic parameters of cameras.
+        Use visp_hand2eye_calibration to determine the extrinsic parameters
+        of cameras.
     </description>
 
     <maintainer email="marco.esposito@tum.de">Marco Esposito</maintainer>
@@ -14,16 +14,14 @@
     <author email="marco.esposito@tum.de">Marco Esposito</author>
 
     <buildtool_depend>catkin</buildtool_depend>
+
     <build_depend>message_generation</build_depend>
-    <exec_depend>message_runtime</exec_depend>
-    <depend>std_msgs</depend>
+
     <depend>geometry_msgs</depend>
+    <depend>std_msgs</depend>
     <depend>std_srvs</depend>
     <depend>visp_hand2eye_calibration</depend>
 
-    <exec_depend>tf</exec_depend>
+    <exec_depend>message_runtime</exec_depend>
     <exec_depend>tf2_ros</exec_depend>
-    
-    <export>
-    </export>
 </package>

--- a/rqt_easy_handeye/CMakeLists.txt
+++ b/rqt_easy_handeye/CMakeLists.txt
@@ -8,7 +8,10 @@ catkin_python_setup()
 catkin_package( )
 
 install(PROGRAMS
-    scripts/rqt_easy_handeye
+    scripts/rqt_calibrationmovements
+    scripts/${PROJECT_NAME}
+    src/${PROJECT_NAME}/rqt_calibrationmovements.py
+    src/${PROJECT_NAME}/${PROJECT_NAME}.py
     DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 

--- a/rqt_easy_handeye/package.xml
+++ b/rqt_easy_handeye/package.xml
@@ -11,6 +11,7 @@
     <author email="marco.esposito@tum.de">Marco Esposito</author>
 
     <buildtool_depend>catkin</buildtool_depend>
+
     <exec_depend>rospy</exec_depend>
     <exec_depend>rqt_gui</exec_depend>
     <exec_depend>rqt_gui_py</exec_depend>


### PR DESCRIPTION
Wanting to follow up on [my comment](https://github.com/IFL-CAMP/easy_handeye/issues/1#issuecomment-509984232) I started with running `catkin_lint`, and then encountered error `catkin ValueError: Set of coroutines/Futures is empty.` which stems from the circular dependency introduced by adding the `exec_depend` from the comment.

I thought I'd still at least let you know about these commits while thinking about the former issue.