### PR TITLE
Complete tf2 transition

### DIFF
--- a/easy_handeye/launch/calibrate.launch
+++ b/easy_handeye/launch/calibrate.launch
@@ -28,7 +28,7 @@
     <arg name="robot_velocity_scaling" default="0.3" doc="the maximum speed the robot should reach, as a factor of the speed declared in the joint_limits.yaml" />
     <arg name="robot_acceleration_scaling" default="0.2" doc="the maximum acceleration the robot should reach, as a factor of the acceleration declared in the joint_limits.yaml" />
     
-    <!-- Dummy calibration to have a fully connected tf tree and see all frames -->
+    <!-- Dummy calibration to have a fully connected TF tree and see all frames -->
     <group if="$(arg publish_dummy)">
         <node unless="$(arg eye_on_hand)" name="dummy_handeye" pkg="tf2_ros" type="static_transform_publisher"
             args="1 1 1 0 1.5 0 $(arg robot_base_frame) $(arg tracking_base_frame)" />

--- a/easy_handeye/launch/calibrate.launch
+++ b/easy_handeye/launch/calibrate.launch
@@ -28,12 +28,12 @@
     <arg name="robot_velocity_scaling" default="0.3" doc="the maximum speed the robot should reach, as a factor of the speed declared in the joint_limits.yaml" />
     <arg name="robot_acceleration_scaling" default="0.2" doc="the maximum acceleration the robot should reach, as a factor of the acceleration declared in the joint_limits.yaml" />
     
-    <!-- Dummy calibration to have a fully connected TF tree and see all frames -->
+    <!-- Dummy calibration to have a fully connected tf tree and see all frames -->
     <group if="$(arg publish_dummy)">
-        <node unless="$(arg eye_on_hand)" name="dummy_handeye" pkg="tf" type="static_transform_publisher"
-            args="1 1 1 0 1.5 0 $(arg robot_base_frame) $(arg tracking_base_frame) 10" />
-        <node if="$(arg eye_on_hand)" name="dummy_handeye" pkg="tf" type="static_transform_publisher"
-            args="0 0 0.05 0 0 0 $(arg robot_effector_frame) $(arg tracking_base_frame) 10" />
+        <node unless="$(arg eye_on_hand)" name="dummy_handeye" pkg="tf2_ros" type="static_transform_publisher"
+            args="1 1 1 0 1.5 0 $(arg robot_base_frame) $(arg tracking_base_frame)" />
+        <node if="$(arg eye_on_hand)" name="dummy_handeye" pkg="tf2_ros" type="static_transform_publisher"
+            args="0 0 0.05 0 0 0 $(arg robot_effector_frame) $(arg tracking_base_frame)" />
     </group>
 
     <!-- Run the ViSP solver to determine the extrinsic parameters -->

--- a/easy_handeye/src/easy_handeye/handeye_calibration.py
+++ b/easy_handeye/src/easy_handeye/handeye_calibration.py
@@ -208,4 +208,3 @@ class HandeyeCalibration(object):
 
         for tp in transf_params:
             rospy.set_param('transformation/'+tp, calib_dict['transformation'][tp])
-

--- a/rqt_easy_handeye/src/rqt_easy_handeye/rqt_calibrationmovements.py
+++ b/rqt_easy_handeye/src/rqt_easy_handeye/rqt_calibrationmovements.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python2
 from __future__ import division
-from easy_handeye.handeye_client import HandeyeClient
+# from easy_handeye.handeye_client import HandeyeClient
 from tf.transformations import quaternion_multiply, quaternion_from_euler
 from geometry_msgs.msg import Quaternion
 from moveit_commander import MoveGroupCommander
@@ -22,7 +22,8 @@ import sys
 
 class CalibrationMovements:
     def __init__(self, move_group_name, max_velocity_scaling=0.5, max_acceleration_scaling=0.5):
-        #self.client = HandeyeClient()  # TODO: move around marker when eye_on_hand, automatically take samples via trigger topic
+        # self.client = HandeyeClient()
+        # TODO: move around marker when eye_on_hand, automatically take samples via trigger topic
         self.mgc = MoveGroupCommander(move_group_name)
         self.mgc.set_planner_id("RRTConnectkConfigDefault")
         self.mgc.set_max_velocity_scaling_factor(max_velocity_scaling)
@@ -228,7 +229,6 @@ class CalibrationMovementsGUI(QWidget):
         can_move = self.state == CalibrationMovementsGUI.GOOD_PLAN
         self.execute_btn.setEnabled(can_move)
 
-
     def handle_check_current_state(self):
         self.local_mover.compute_poses_around_current_state(self.angle_delta, self.translation_delta)
 
@@ -258,7 +258,8 @@ class CalibrationMovementsGUI(QWidget):
         self.guide_lbl.setText('Planning to the next position. Click on execute when a good one was found')
         if self.current_pose >= 0:
             self.current_plan = self.local_mover.plan_to_pose(self.local_mover.poses[self.current_pose])
-            if CalibrationMovements.is_crazy_plan(self.current_plan, self.local_mover.fallback_joint_limits):  #TODO: sort out this limits story
+            if CalibrationMovements.is_crazy_plan(self.current_plan, self.local_mover.fallback_joint_limits):
+                # TODO: sort out this limits story
                 self.state = CalibrationMovementsGUI.BAD_PLAN
             else:
                 self.state = CalibrationMovementsGUI.GOOD_PLAN
@@ -317,6 +318,7 @@ class RqtCalibrationMovements(Plugin):
     # Comment in to signal that the plugin has a way to configure
     # This will enable a setting button (gear icon) in each dock widget title bar
     # Usually used to open a modal configuration dialog
+
 
 if __name__ == '__main__':
 


### PR DESCRIPTION
I don't particularly like how handeye_calibrator came out, but it does seem to be correctly converted. Many things were not needed anymore, but the diff doesn't really pick the changes up correctly.

Also of note is the fact that now it seems every time one takes the n-th sample there's 2n deep copies happening (it probably was the same way before as well but the package wasn't printing `deep copy` with each sample).

And I also couldn't find an alternative to `tf.transformations` for rqt_calibrationmovements.py