### PR TITLE
Add param for calibration file location

### DIFF
--- a/easy_handeye/launch/publish.launch
+++ b/easy_handeye/launch/publish.launch
@@ -11,6 +11,7 @@
     <arg name="tracking_base_frame" default="" />
     
     <arg name="inverse" default="false" />
+    <arg name="calibration_file" default="" />
     
     <!--publish hand-eye calibration-->
     <group ns="$(arg namespace)">
@@ -19,6 +20,7 @@
         <param if="$(arg eye_on_hand)" name="robot_effector_frame" value="$(arg robot_effector_frame)" />
         <param name="tracking_base_frame" value="$(arg tracking_base_frame)" />
         <param name="inverse" value="$(arg inverse)" />
+        <param name="calibration_file" value="$(arg calibration_file)" />
         <node name="$(anon handeye_publisher)" pkg="easy_handeye" type="publish.py" output="screen"/>
     </group>
 </launch>

--- a/easy_handeye/scripts/publish.py
+++ b/easy_handeye/scripts/publish.py
@@ -11,8 +11,10 @@ while rospy.get_time() == 0.0:
     pass
 
 inverse = rospy.get_param('inverse')
+filename = rospy.get_param('calibration_file')
+print("filename", filename)
 
-calib = HandeyeCalibration.from_file(rospy.get_namespace())
+calib = HandeyeCalibration.from_filename(filename)
 
 if calib.parameters.eye_on_hand:
     overriding_robot_effector_frame = rospy.get_param('robot_effector_frame')

--- a/easy_handeye/scripts/publish.py
+++ b/easy_handeye/scripts/publish.py
@@ -12,9 +12,12 @@ while rospy.get_time() == 0.0:
 
 inverse = rospy.get_param('inverse')
 filename = rospy.get_param('calibration_file')
-print("filename", filename)
+rospy.loginfo("filename", filename)
 
-calib = HandeyeCalibration.from_filename(filename)
+if filename == '':
+    calib = HandeyeCalibration.from_file(rospy.get_namespace())
+else:
+    calib = HandeyeCalibration.from_filename(filename)
 
 if calib.parameters.eye_on_hand:
     overriding_robot_effector_frame = rospy.get_param('robot_effector_frame')

--- a/easy_handeye/src/easy_handeye/handeye_calibration.py
+++ b/easy_handeye/src/easy_handeye/handeye_calibration.py
@@ -253,3 +253,14 @@ class HandeyeCalibration(object):
 
         with open(HandeyeCalibration.filename_for_namespace(namespace)) as calib_file:
             return HandeyeCalibration.from_yaml(calib_file.read())
+
+    @staticmethod
+    def from_filename(filename):
+        """
+        Parses a yaml file at the specified location.
+
+        :rtype: None
+        """
+
+        with open(filename) as calib_file:
+            return HandeyeCalibration.from_yaml(calib_file.read())


### PR DESCRIPTION
This MR adds a parameter to the `publish.launch` file to specify the location of the calibration file instead of assuming the file is at the default location.