### PR TITLE
use safe_load instead of load

### DIFF
--- a/easy_handeye/src/easy_handeye/handeye_calibration.py
+++ b/easy_handeye/src/easy_handeye/handeye_calibration.py
@@ -177,7 +177,7 @@ class HandeyeCalibration(object):
         :param in_yaml: a yaml string
         :rtype: None
         """
-        return HandeyeCalibration.from_dict(yaml.load(in_yaml))
+        return HandeyeCalibration.from_dict(yaml.safe_load(in_yaml))
 
     @staticmethod
     def init_from_parameter_server(namespace):


### PR DESCRIPTION
Workaround for the following error
```
TypeError: load() missing 1 required positional argument: 'Loader' 
```
Please check https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation